### PR TITLE
force numpy<2, numba cannot deal with numpy>=2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    'numpy',
+    'numpy<2',
     'scipy',
     'matplotlib',
     'pyfar',


### PR DESCRIPTION
force numpy <2, due to numba. This is a work around until numba is an optional package