### PR TITLE
hotfix: remove numba calls from geometry.py functions

### DIFF
--- a/sparrowpy/geometry.py
+++ b/sparrowpy/geometry.py
@@ -465,7 +465,7 @@ def _calculate_normals(points: np.ndarray):
 
     normals = np.empty((points.shape[0],3))
 
-    for i in numba.prange(points.shape[0]):
+    for i in prange(points.shape[0]):
         normals[i]=np.cross(points[i][1]-points[i][0],points[i][2]-points[i][0])
         normals[i]/=np.linalg.norm(normals[i])
 
@@ -738,8 +738,8 @@ def _coincidence_check(p0: np.ndarray, p1: np.ndarray, thres = 1e-6) -> bool:
     """
     flag = False
 
-    for i in numba.prange(p0.shape[0]):
-        for j in numba.prange(p1.shape[0]):
+    for i in prange(p0.shape[0]):
+        for j in prange(p1.shape[0]):
             if np.linalg.norm(p0[i]-p1[j])<thres:
                 flag=True
                 break


### PR DESCRIPTION
ISSUE:
Some functions in geometry.py still called `numba.prange` instead of `prange` in some loops.
This caused errors whenever numba was not installed.


This PR removes these references to numba.