### PR TITLE
improve tests performance

### DIFF
--- a/tests/test_DRadiosityFast.py
+++ b/tests/test_DRadiosityFast.py
@@ -8,12 +8,12 @@ import sparrowpy as sp
 
 
 def test_init(sample_walls):
-    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, 0.2)
-    npt.assert_almost_equal(radiosity.patches_points.shape, (150, 4, 3))
-    npt.assert_almost_equal(radiosity.patches_area.shape, (150))
-    npt.assert_almost_equal(radiosity.patches_center.shape, (150, 3))
-    npt.assert_almost_equal(radiosity.patches_size.shape, (150, 3))
-    npt.assert_almost_equal(radiosity.patches_normal.shape, (150, 3))
+    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, 0.5)
+    npt.assert_almost_equal(radiosity.patches_points.shape, (24, 4, 3))
+    npt.assert_almost_equal(radiosity.patches_area.shape, (24))
+    npt.assert_almost_equal(radiosity.patches_center.shape, (24, 3))
+    npt.assert_almost_equal(radiosity.patches_size.shape, (24, 3))
+    npt.assert_almost_equal(radiosity.patches_normal.shape, (24, 3))
 
 
 def test_check_visibility(sample_walls):
@@ -29,7 +29,7 @@ def test_check_visibility(sample_walls):
 
 
 def test_check_visibility_wrapper(sample_walls):
-    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, 0.2)
+    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, 0.5)
     radiosity.bake_geometry()
     visibility_matrix = sp.geometry._check_patch2patch_visibility(
         radiosity.patches_center, radiosity.patches_normal,
@@ -38,12 +38,9 @@ def test_check_visibility_wrapper(sample_walls):
 
 
 def test_compute_form_factors(sample_walls):
-    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, 0.2)
+    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, .5)
     radiosity.bake_geometry()
-    npt.assert_almost_equal(radiosity.form_factors.shape, (150, 150))
-    radiosity.bake_geometry()
-    npt.assert_almost_equal(radiosity.form_factors.shape, (150, 150))
-
+    npt.assert_almost_equal(radiosity.form_factors.shape, (24, 24))
 
 
 @pytest.mark.parametrize('walls', [

--- a/tests/test_DRadiosityFast.py
+++ b/tests/test_DRadiosityFast.py
@@ -17,15 +17,14 @@ def test_init(sample_walls):
 
 
 def test_check_visibility(sample_walls):
-    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, 0.2)
+    radiosity = sp.DirectionalRadiosityFast.from_polygon(sample_walls, .5)
     radiosity.bake_geometry()
-    npt.assert_almost_equal(radiosity._visibility_matrix.shape, (150, 150))
-    # npt.assert_array_equal(
-    #     radiosity._visibility_matrix, radiosity._visibility_matrix.T)
-    npt.assert_array_equal(radiosity._visibility_matrix[:25, :25], False)
-    npt.assert_array_equal(radiosity._visibility_matrix[:25, 25:], True)
-    npt.assert_array_equal(radiosity._visibility_matrix[25:50, 25:50], False)
-    assert np.sum(radiosity._visibility_matrix) == 25*5*25*6/2
+    npt.assert_almost_equal(radiosity._visibility_matrix.shape, (24,24))
+    for i in range(6):
+        k = i*4
+        npt.assert_array_equal(radiosity._visibility_matrix[k+4:, k:k+4], False)
+        npt.assert_array_equal(radiosity._visibility_matrix[k:k+4, k+4:], True)
+    assert np.sum(radiosity._visibility_matrix) == 24**2-21*4**2
 
 
 def test_check_visibility_wrapper(sample_walls):

--- a/tests/test_DRadiosityFast.py
+++ b/tests/test_DRadiosityFast.py
@@ -22,8 +22,10 @@ def test_check_visibility(sample_walls):
     npt.assert_almost_equal(radiosity._visibility_matrix.shape, (24,24))
     for i in range(6):
         k = i*4
-        npt.assert_array_equal(radiosity._visibility_matrix[k+4:, k:k+4], False)
-        npt.assert_array_equal(radiosity._visibility_matrix[k:k+4, k+4:], True)
+        npt.assert_array_equal(radiosity._visibility_matrix[k+4:, k:k+4],
+                               False)
+        npt.assert_array_equal(radiosity._visibility_matrix[k:k+4, k+4:],
+                               True)
     assert np.sum(radiosity._visibility_matrix) == 24**2-21*4**2
 
 

--- a/tests/test_DRadiosityFast_order.py
+++ b/tests/test_DRadiosityFast_order.py
@@ -52,14 +52,14 @@ def test_order_vs_analytic(patch_size):
     # note that order k=0 means one reflection and k=1 means two reflections
     # (2nd order)
     X = 5
-    Y = 6
+    Y = 3
     Z = 4
     length_histogram = .15
-    time_resolution = 1/1000
+    time_resolution = 1/500
     max_order_k = 3
     speed_of_sound = 346.18
-    receiver = pf.Coordinates(3, 4, 2)
-    source = pf.Coordinates(2, 2, 2)
+    receiver = pf.Coordinates(3, 1.5, 2)
+    source = pf.Coordinates(2, 1.5, 2)
 
     absorption = 0.1
 
@@ -111,10 +111,7 @@ def test_order_vs_analytic(patch_size):
     etc_analytic_db = 10*np.log10(reverberation_analytic.flatten())
 
     # compare the diffuse part
-    samples_reverb_start = int(0.025/time_resolution)
-    samples_reverb_end = int(0.035/time_resolution)
     npt.assert_allclose(
-        etc_radiosity_db[samples_reverb_start:samples_reverb_end],
-        etc_analytic_db[samples_reverb_start:samples_reverb_end],
-        atol=0.3)
-
+        etc_radiosity_db[5:19],
+        etc_analytic_db[5:19],
+        atol=2) # maximal 2dB difference

--- a/tests/test_DirectionalRadiosityFast.py
+++ b/tests/test_DirectionalRadiosityFast.py
@@ -70,7 +70,7 @@ def test_io(apply_brdf, apply_attenuation, tmpdir):
 
 
 def test_io_within_simulation(tmpdir):
-    walls = sp.testing.shoebox_room_stub(5, 6, 4)
+    walls = sp.testing.shoebox_room_stub(1, 1, 1)
     radiosity = sp.DirectionalRadiosityFast.from_polygon(
         walls, 1)
 

--- a/tests/test_Radiosity.py
+++ b/tests/test_Radiosity.py
@@ -82,11 +82,11 @@ def test_small_room_and_shift():
 def test_small_room_and_rotate():
     """Test if the results changes for rotated walls."""
     X = 5
-    Y = 6
+    Y = 3
     Z = 4
-    r_x = 3
+    r_x = 1
     r_y = 2
-    r_z = 3
+    r_z = 1.5
     patch_size = 1
     ir_length_s = 1
     sampling_rate = 1


### PR DESCRIPTION
### Changes proposed in this pull request:

- complexity of tests is reduced, where ever possible
- example: on develop 126.07s and in this pr 96.74s on my local mashine


### 10 slowest tests now:
```
========================================================= slowest 10 durations ==========================================================
12.51s call     tests/test_DRadiosityFast.py::test_check_visibility
7.72s call     tests/test_multisource.py::test_multi_receiver[receivers0-frequencies0]
6.50s call     tests/test_DRadiosityFast_infinite_diffuse_plane.py::test_colocated_source_receiver[1]
5.30s call     tests/test_Radiosity.py::test_small_room_and_rotate
4.42s call     tests/test_Radiosity.py::test_small_room_and_shift
4.03s call     tests/test_multisource.py::test_multi_receiver[receivers0-frequencies1]
3.56s call     tests/test_DirectionalRadiosityFast.py::test_io[True-True]
2.96s call     tests/test_DRadiosityFast.py::test_init
2.01s call     tests/test_DRadiosityFast_order.py::test_order_vs_analytic[1]
1.82s call     tests/test_universal_formfactor.py::test_parallel_facing_patches[1.0-1.0-1.0]
============================================= 502 passed, 622 warnings in 96.74s (0:01:36) ==============================================
```

### 10 slowest test develop:
```
========================================================= slowest 10 durations ==========================================================
13.05s call     tests/test_Radiosity.py::test_small_room_and_rotate
11.91s call     tests/test_DRadiosityFast.py::test_check_visibility
10.07s call     tests/test_DirectionalRadiosityFast.py::test_io_within_simulation
8.04s call     tests/test_multisource.py::test_multi_receiver[receivers0-frequencies0]
6.30s call     tests/test_DRadiosityFast.py::test_compute_form_factors
6.16s call     tests/test_DRadiosityFast_infinite_diffuse_plane.py::test_colocated_source_receiver[1]
5.54s call     tests/test_DRadiosityFast.py::test_check_visibility_wrapper
4.79s call     tests/test_multisource.py::test_multi_receiver[receivers0-frequencies1]
4.37s call     tests/test_Radiosity.py::test_small_room_and_shift
4.07s call     tests/test_DRadiosityFast_order.py::test_order_vs_analytic[1]
============================================= 502 passed, 622 warnings in 126.07s (0:02:06) =============================================
```