### PR TITLE
static light-weight method for contour integration

### DIFF
--- a/sparrowpy/form_factor/integration.py
+++ b/sparrowpy/form_factor/integration.py
@@ -659,3 +659,4 @@ if numba is not None:
     _surf_sample_regulargrid = numba.njit()(_surf_sample_regulargrid)
     _sample_boundary_regular = numba.njit()(_sample_boundary_regular)
     _area_under_curve = numba.njit()(_area_under_curve)
+    _booles_rule = numba.njit()(_booles_rule)

--- a/sparrowpy/form_factor/integration.py
+++ b/sparrowpy/form_factor/integration.py
@@ -109,12 +109,7 @@ def stokes_integration(
             if np.abs(xi[-1]-xi[0])>1e-3:
                 for k in range(len(segi)):
                     subseci[k] = inner_integral[segi[k]][dim]
-                h=xi[1]-xi[0]
-                outer_integral+= 2*h/45 *( 7*subsecj[0] +
-                                          32*subsecj[1] +
-                                          12*subsecj[2] +
-                                          32*subsecj[3] +
-                                           7*subsecj[4])
+                outer_integral+= _booles_rule(xi,subseci)
 
     return np.abs(outer_integral/(2*np.pi*patch_i_area))
 

--- a/sparrowpy/form_factor/integration.py
+++ b/sparrowpy/form_factor/integration.py
@@ -97,12 +97,7 @@ def stokes_integration(
                     for k in range(len(segj)):
                         subsecj[k] = form_mat[i][segj[k]]
 
-                    h=xj[1]-xj[0]
-                    inner_integral[i][dim]+= 2*h/45 *(7*subsecj[0] +
-                                                      32*subsecj[1] +
-                                                      12*subsecj[2] +
-                                                      32*subsecj[3] +
-                                                      7*subsecj[4])
+                    inner_integral[i][dim]+=_booles_rule(xj,subsecj)
 
 
 
@@ -469,6 +464,23 @@ def _area_under_curve(ps: np.ndarray, order=2) -> float:
 
     return area
 
+def _booles_rule(x,y):
+    """Integrate 1D function after Boole's rule.
+
+    Parameters
+    ----------
+    x: np.ndarray(float)
+        x-coordinate of the input samples.
+    y: np.ndarray(float)
+        f(x) of the input samples.
+    """
+
+    h=x[1]-x[0]
+    return 2*h/45 *(7*y[0] +
+                    32*y[1] +
+                    12*y[2] +
+                    32*y[3] +
+                    7*y[4])
 
 ####################################################
 # sampling

--- a/sparrowpy/form_factor/integration.py
+++ b/sparrowpy/form_factor/integration.py
@@ -97,7 +97,7 @@ def stokes_integration(
                     for k in range(len(segj)):
                         subsecj[k] = form_mat[i][segj[k]]
 
-                    inner_integral[i][dim]+=_booles_rule(xj,subsecj)
+                    inner_integral[i][dim]+=_newton_cotes_4th(xj,subsecj)
 
 
 
@@ -109,7 +109,7 @@ def stokes_integration(
             if np.abs(xi[-1]-xi[0])>1e-3:
                 for k in range(len(segi)):
                     subseci[k] = inner_integral[segi[k]][dim]
-                outer_integral+= _booles_rule(xi,subseci)
+                outer_integral+= _newton_cotes_4th(xi,subseci)
 
     return np.abs(outer_integral/(2*np.pi*patch_i_area))
 
@@ -459,8 +459,16 @@ def _area_under_curve(ps: np.ndarray, order=2) -> float:
 
     return area
 
-def _booles_rule(x,y):
+def _newton_cotes_4th(x: np.ndarray,y):
     """Integrate 1D function after Boole's rule.
+
+    Returns the approximate integral of a given function f(x)
+    given 5 equally spaced samples (x,y).
+    x samples the function input, while y samples the respective f(x) values.
+
+    The integral is numerically estimated via the closed 4th-order
+    Newton-Cotes formula (aka Boole's Rule).
+    This formula *requires* 5 equidistant sample input.
 
     Parameters
     ----------
@@ -654,4 +662,4 @@ if numba is not None:
     _surf_sample_regulargrid = numba.njit()(_surf_sample_regulargrid)
     _sample_boundary_regular = numba.njit()(_sample_boundary_regular)
     _area_under_curve = numba.njit()(_area_under_curve)
-    _booles_rule = numba.njit()(_booles_rule)
+    _newton_cotes_4th = numba.njit()(_newton_cotes_4th)

--- a/sparrowpy/form_factor/universal.py
+++ b/sparrowpy/form_factor/universal.py
@@ -91,8 +91,7 @@ def universal_form_factor(source_pts: np.ndarray, source_normal: np.ndarray,
     else:
         form_factor = integration.stokes_integration(patch_i=source_pts,
                                              patch_j=receiver_pts,
-                                             patch_i_area=source_area,
-                                             approx_order=4)
+                                             patch_i_area=source_area)
 
     return form_factor
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- numerical contour integration of the form factors now a fixed formula ([Boole's Rule](https://en.wikipedia.org/wiki/Boole%27s_rule))
    - before, wasted resources in "clever" interpolation and integration methods
    - Boole's rule outputs _exactly_ the same result as the prior method with polynomial order 4. 
- polynomial order of the integration fixed (4)
    - was unnecessary variable anyways


paves the way for composite methods -- better for large patch sizes

